### PR TITLE
이미지 파일링크가 안보내지는 부분 수정완료

### DIFF
--- a/src/main/resources/static/js/point.js
+++ b/src/main/resources/static/js/point.js
@@ -137,7 +137,7 @@ async function drawImageWithSerialNumber(imageSrc) {
 document.getElementById("gifticon").addEventListener('click', function() {
     event.preventDefault();
     const imageSrc = this.parentElement.querySelector('#file_name').value;
-    const changedsrc = drawImageWithSerialNumber(imageSrc);
+    const changedsrc = await drawImageWithSerialNumber(imageSrc);
     console.log(changedsrc)
     this.parentElement.querySelector('#file_name').value = changedsrc
     elements = this.parentElement


### PR DESCRIPTION
await 키워드를 사용하여 drawImageWithSerialNumber 함수가 이미지를 처리하고 
Cloudinary에 업로드하는 작업이 완료될 때까지 기다리게해야 이미지 파일링크가 값으로 받아와 짐